### PR TITLE
update default log level to error instead of info

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -40,8 +40,8 @@ func newLogger(logFile, level string) *logrus.Logger {
 
 	logLevel, err := logrus.ParseLevel(level)
 	if err != nil {
-		logrus.Warnln("Could not parse log level, defaulting to info. Error:", err.Error())
-		logLevel = logrus.InfoLevel
+		logrus.Warnln("Could not parse log level, defaulting to error. Error:", err.Error())
+		logLevel = logrus.ErrorLevel
 	}
 
 	formatter := &logrus.TextFormatter{


### PR DESCRIPTION
```
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
```
It seems log mode is not working as expected, and we need an immediate fix to reduce the log as it is costing too much. will send another PR with the actual fix. 

 tried and it is still showing lot of info and warning logs. 
        - --log-mode=Error