### PR TITLE
Make go version util minor path to avoid invalid version error in dependency modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/AthenZ/k8s-athenz-syncer
 
-go 1.22
+go 1.22.0
+
+toolchain go1.22.4
 
 require (
 	github.com/AthenZ/athenz v1.11.59

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/AthenZ/k8s-athenz-syncer
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/AthenZ/athenz v1.11.59


### PR DESCRIPTION
## What changes made in this PR

Use the correct format for go version in go.mod file

```
go: errors parsing go.mod:
/go/src/github.com/yahoo/k8s-athenz-syncer/go.mod:3: invalid go version '1.22.0': must match format 1.23
```



I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


<img width="1637" alt="Screenshot 2024-06-20 at 6 35 29 PM" src="https://github.com/AthenZ/k8s-athenz-syncer/assets/157670300/0eb8f7de-8ac8-4f8b-acfe-a319a8005692">
